### PR TITLE
Minor fixes in Gradle config: change mainClassName and force Randoop download

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
 }
 //apply plugin: 'kotlin'
 
-mainClassName = "org.memo.Toradocu"
+mainClassName = "org.memo.MeMo"
 apply plugin: 'com.github.johnrengelman.shadow' // Workaround for https://github.com/johnrengelman/shadow/issues/336
 
 task downloadRandoop(type: Download) {
@@ -285,6 +285,8 @@ compileJava {
   options.compilerArgs << '-Xlint:unchecked,deprecation'
   options.encoding = 'UTF-8'
 }
+
+compileJava.dependsOn(downloadRandoop)
 
 repositories {
   mavenCentral()


### PR DESCRIPTION
I was getting two different errors when trying to compile and run the program:
 - When compiling, the Randoop library was not being downloaded automatically so it would fail building the project.
 - When running the program, the error `Error: Could not find or load main class org.memo.Toradocu` was being returned, because the main class does not match the one configured in Gradle.

This PR should fix both issues.